### PR TITLE
#793: Reference pro_plan images with templatetag

### DIFF
--- a/resources/views/header.blade.php
+++ b/resources/views/header.blade.php
@@ -784,11 +784,11 @@
             <div class="row">
                 <div class="col-md-6">
                     <h4>{{ trans('texts.before') }}</h4>
-                    <img src="{{ BLANK_IMAGE }}" data-src="http://ninja.dev/images/pro_plan/white_label_before.png" width="100%" alt="before">
+                    <img src="{{ BLANK_IMAGE }}" data-src="{{ asset('images/pro_plan/white_label_before.png') }}" width="100%" alt="before">
                 </div>
                 <div class="col-md-6">
                     <h4>{{ trans('texts.after') }}</h4>
-                    <img src="{{ BLANK_IMAGE }}" data-src="http://ninja.dev/images/pro_plan/white_label_after.png" width="100%" alt="after">
+                    <img src="{{ BLANK_IMAGE }}" data-src="{{ asset('images/pro_plan/white_label_after.png') }}" width="100%" alt="after">
                 </div>
             </div>
           </div>


### PR DESCRIPTION
Updated references to the pro_plan before- and after-images with the asset-templatetag. They were referenced by `ninja.dev`, which doesn't resolve on a lot of computers